### PR TITLE
Fix issue with local file being generated and add support for array of tags.

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -65,13 +65,13 @@ function logger(options) {
         ]
     });
 
-    if (typeof options.logzio.tag !== 'undefined') {
+    if (typeof options.logzio.tag !== 'undefined' || Array.isArray(options.logzio.tags)) {
         Logger.add(logzioWinstonTransport,
             {
                 bufferSize: options.logzio.bufferSize || 1,
                 debug: options.logzio.debug || false,
                 extraFields: {
-                    tags: [options.logzio.tag]
+                    tags: options.logzio.tag ? [options.logzio.tag] : options.logzio.tags
                 },
                 level: process.env.LOGZIO_LOG_LEVEL || 'important',
                 sendIntervalMs: options.logzio.sendIntervalMS || 1000 * 2,

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -24,6 +24,7 @@ function logger(options) {
 
     options = options || {};
     options.console = options.console || {};
+    options.file = options.file || {};
     options.logzio = options.logzio || {};
 
     Logger = new winston.Logger({
@@ -48,7 +49,6 @@ function logger(options) {
             important: 'green'
         },
         transports: [
-            new (winston.transports.File)({filename: 'logs.log'}),
             new winston.transports.Console({
                 colorize: options.console.colorize || true,
                 formatter: options.console.formatter || undefined,
@@ -64,6 +64,10 @@ function logger(options) {
             })
         ]
     });
+
+    if (typeof options.file.filename === 'string' && options.file.filename.length !== 0) {
+        Logger.add(new (winston.transports.File)(options.file));
+    }
 
     if (typeof options.logzio.tag !== 'undefined' || Array.isArray(options.logzio.tags)) {
         Logger.add(logzioWinstonTransport,


### PR DESCRIPTION
This PR addresses both issues.  Perhaps more urgently, the local file issue is addressed by making using a file transport optional and configurable (through "options.file").  It also allows passing multiple tags by now accepting an array for the tag parameter. #5 #6