### PR TITLE
update winston-logzio dep from 1.0.0 to 1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "nconf": "0.8.4",
     "winston": "2.2.0",
-    "winston-logzio": "1.0.0"
+    "winston-logzio": "1.0.3"
   },
   "devDependencies": {
     "changelog-maker": "2.2.3",


### PR DESCRIPTION
> Snyk gives us a security venerability error for one of the modules that are included from cnn-logger.
>  
> ✗ High severity vulnerability found on tough-cookie@2.2.2
> - desc: ReDoS via long string of semicolons
> - info: https://snyk.io/vuln/npm:tough-cookie:20160722
> - from: cnn-verticals-runner@1.3.3 > logzio-nodejs@0.3.10 > request@2.68.0 > tough-cookie@2.2.2
> Upgrade direct dependency logzio-nodejs@0.3.10 to logzio-nodejs@0.4.1 (triggers upgrades to request@2.75.0 > tough-cookie@2.3.0)
>  
> This should be easy to fix. We need to upgrade to use winston-logzio@1.0.3 that uses the latest version of logzio-nodejs.