### PR TITLE
add support for passing log level via options

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -54,7 +54,7 @@ function logger(options) {
                 formatter: options.console.formatter || undefined,
                 handleExceptions: options.console.handleExceptions || true,
                 json: options.console.json || false,
-                level: process.env.LOG_LEVEL || 'important',
+                level: process.env.LOG_LEVEL || options.console.logLevel || 'important',
                 prettyPrint: options.console.prettyPrint || true,
                 showLevel: options.console.showLevel || true,
                 silent: options.console.silent || false,
@@ -77,7 +77,7 @@ function logger(options) {
                 extraFields: {
                     tags: options.logzio.tag ? [options.logzio.tag] : options.logzio.tags
                 },
-                level: process.env.LOGZIO_LOG_LEVEL || 'important',
+                level: process.env.LOGZIO_LOG_LEVEL || options.logzio.logLevel || 'important',
                 sendIntervalMs: options.logzio.sendIntervalMS || 1000 * 2,
                 token: process.env.LOGZIO_TOKEN
             }


### PR DESCRIPTION
# What does this PR do?
Adds support for passing in a log level via `options.console.logLevel` or `options.logzio.logLevel`

# Why is this PR needed?
Environment variables are not necessarily always set in a development scenario - it's nice to be able to change this via the configuration object passed in. Previously, only `important` messages would be output.

# Running this branch
```bash
cd path/to/cnn-logger/
git pull
git checkout log-level
```
Set up a test file
```js
const logger = require('path/to/cnn-logger')({ console: { logLevel: 'silly' } });
log.silly('Hello World!');
```