### PR TITLE
Add do_<level> booleans, like do_debug and do_warn

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -20,12 +20,17 @@ function logger(options) {
     const winston = require('winston'),
         logzioWinstonTransport = require('winston-logzio');
 
-    let Logger;
+    let Logger,
+        maxLevel = 'important',
+        maxValue = 0;
 
     options = options || {};
     options.console = options.console || {};
+    options.console.logLevel = process.env.CONSOLE_LOG_LEVEL || options.console.logLevel || process.env.LOG_LEVEL || 'important';
     options.file = options.file || {};
+    options.file.level = options.file.level || options.file.logLevel || 'important';
     options.logzio = options.logzio || {};
+    options.logzio.logLevel = process.env.LOGZIO_LOG_LEVEL || options.logzio.logLevel || process.env.LOG_LEVEL || 'important';
 
     Logger = new winston.Logger({
         levels: {
@@ -54,7 +59,7 @@ function logger(options) {
                 formatter: options.console.formatter || undefined,
                 handleExceptions: options.console.handleExceptions || true,
                 json: options.console.json || false,
-                level: process.env.LOG_LEVEL || options.console.logLevel || 'important',
+                level: options.console.logLevel,
                 prettyPrint: options.console.prettyPrint || true,
                 showLevel: options.console.showLevel || true,
                 silent: options.console.silent || false,
@@ -64,6 +69,19 @@ function logger(options) {
             })
         ]
     });
+
+    if (options.console.logLevel !== 'important') {
+        maxLevel = options.console.logLevel;
+        maxValue = Logger.levels[maxLevel];
+    }
+    if (options.file.level !== 'important' && Logger.levels[options.file.level] > maxValue) {
+        maxLevel = options.file.level;
+        maxValue = Logger.levels[maxLevel];
+    }
+    if (options.logzio.logLevel !== 'important' && Logger.levels[options.logzio.logLevel] > maxValue) {
+        maxLevel = options.logzio.logLevel;
+        maxValue = Logger.levels[maxLevel];
+    }
 
     if (typeof options.file.filename === 'string' && options.file.filename.length !== 0) {
         Logger.add(new (winston.transports.File)(options.file));
@@ -77,22 +95,24 @@ function logger(options) {
                 extraFields: {
                     tags: options.logzio.tag ? [options.logzio.tag] : options.logzio.tags
                 },
-                level: process.env.LOGZIO_LOG_LEVEL || options.logzio.logLevel || 'important',
+                level: options.logzio.logLevel,
                 sendIntervalMs: options.logzio.sendIntervalMS || 1000 * 2,
-                token: process.env.LOGZIO_TOKEN
+                token: process.env.LOGZIO_TOKEN || options.logzio.token
             }
         );
     }
 
-    if (options.prependString) {
-        Object.keys(Logger.levels).forEach((level) => {
+    Object.keys(Logger.levels).forEach((level) => {
+        if (options.prependString) {
             Logger[level] = (msg) => {
                 arguments[0] = options.prependString + msg;
                 let args = [level].concat(Array.prototype.slice.call(arguments));
                 Logger.log.apply(Logger, args);
             };
-        });
-    }
+        }
+
+        Logger[`do_${level}`] = (maxValue >= Logger.levels[level]);
+    });
 
     return Logger;
 }


### PR DESCRIPTION
Added a boolean for each level (like "do_debug", "do_warn", and "do_error") so you can quickly determine if anything is logging at that level.  Also made some improvements to setting the log levels, including the addition of using the "CONSOLE_LOG_LEVEL" environment variable, if it is set.
